### PR TITLE
add racer as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coffeeify": "~0.6.0",
     "redis": "~0.10.1",
     "connect-redis": "~1.4.7",
+    "racer": "~0.5.14",
     "racer-browserchannel": "~0.1.1",
     "racer-bundle": "~0.1.1",
     "livedb-mongo": "~0.3.0"


### PR DESCRIPTION
racer-browserchannel depends on racer even though its package.json only adds it as a devDependency
