### PR TITLE
Reuse redis client for session store

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -57,7 +57,7 @@ function setup(app, options) {
     .use(express.cookieParser())
     .use(express.session({
       secret: process.env.SESSION_SECRET || 'YOUR SECRET HERE'
-    , store: new RedisStore()
+    , store: new RedisStore({client: redisClient})
     }))
     .use(createUserId)
 


### PR DESCRIPTION
Hopefully I am not completely missing the point. As it stands, it just tries to connect to `127.0.0.1:6379` again, even if you've painstakingly set up your `REDIS_*` environment variables.
