### PR TITLE
fixed deploy issue

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -66,7 +66,7 @@ function setup(app, options, cb) {
     .use(express.cookieParser())
     .use(express.session({
       secret: process.env.SESSION_SECRET || 'YOUR SECRET HERE'
-    , store: new RedisStore()
+    , store: new RedisStore({client: redisClient})
     }))
     .use(createUserId)
 


### PR DESCRIPTION
This fixed deploy issue on windows azure.

`RedisStore` was trying to connect to wrong redis host/port.
