### PR TITLE
tie to specific derby version for npm 2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/codeparty/derby-starter/issues"
   },
   "dependencies": {
-    "derby": "~0.6",
+    "derby": "0.6.0-alpha28",
     "express": "~3.4.8",
     "coffee-script": "~1.7.1",
     "coffeeify": "~0.6.0",


### PR DESCRIPTION
Changed package.json in a similar way to https://github.com/derbyjs/derby/commit/1c5c1654062c66a1efd38dbb9ebc11e0d44aed22 so that derby-examples can run with npm 2.x
