### PR TITLE
Added an option to open the browser automatically

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var derby = require('derby');
+var spawn = require('child_process').spawn;
 
 exports.run = run;
 
@@ -7,7 +8,12 @@ function run(app, options, cb) {
   var port = options.port || process.env.PORT || 3000;
 
   function listenCallback(err) {
-    console.log('%d listening. Go to: http://localhost:%d/', process.pid, port);
+    if(!options.open) {
+      console.log('%d listening. Go to: http://localhost:%d/', process.pid, port);
+    } else {
+      console.log('%d listening. Opening http://localhost:%d/', process.pid, port);
+      spawn('open', ['http://localhost:' + port + '/']);
+    }
     cb && cb(err);
   }
   function createServer() {


### PR DESCRIPTION
During the development phase, having the browser open automatically is really helpful and time saving.
Especially with the examples.

It will also get annoying really fast, especially when restarting server multiple times, so that why I did not add it as a default behaviour. Well that and for backward compatibility and the fact that opening browser in server is kind of pointless.