### PR TITLE
Fix the issue with dependency derby version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coffeeify": "^1.1.0",
     "compression": "^1.6.0",
     "connect-mongo": "^0.8.2",
-    "derby": "^0.6.0-alpha9",
+    "derby": "^0.7.1",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "mongodb": "^2.0.45",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coffeeify": "^1.1.0",
     "compression": "^1.6.0",
     "connect-mongo": "^0.8.2",
-    "derby": "^0.6.0",
+    "derby": "^0.6.0-alpha9",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "mongodb": "^2.0.45",


### PR DESCRIPTION
Issue https://github.com/derbyjs/derby-starter/issues/16, `npm ERR! No compatible version found: derby@^0.6.0`.