### PR TITLE
Update derby and fix master

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,18 +20,18 @@ function setup(app, options, cb) {
       (process.env.MONGO_PORT || 27017) + '/' +
       (process.env.MONGO_DB || 'derby-' + (app.name || 'app'));
 
-  var store = derby.createStore({
+  var backend = derby.createBackend({
     db: new ShareDbMongo(mongoUrl)
   });
 
-  store.on('bundle', function(browserify) {
+  backend.on('bundle', function(browserify) {
     // Add support for directly requiring coffeescript in browserify bundles
     browserify.transform({global: true}, coffeeify);
   });
 
   var publicDir = __dirname + '/../public';
 
-  var handlers = highway(store);
+  var handlers = highway(backend);
 
   var expressApp = express()
     .use(favicon(publicDir + '/favicon.ico'))
@@ -41,10 +41,12 @@ function setup(app, options, cb) {
 
   expressApp
     // Adds req.getModel method
-    .use(store.modelMiddleware())
+    .use(backend.modelMiddleware())
     .use(session({
       secret: process.env.SESSION_SECRET || 'YOUR SECRET HERE'
     , store: new MongoStore({url: mongoUrl})
+    , resave: true
+    , saveUninitialized: false
     }))
     .use(handlers.middleware)
     .use(createUserId)
@@ -69,7 +71,7 @@ function setup(app, options, cb) {
     next('404: ' + req.url);
   });
 
-  app.writeScripts(store, publicDir, {extensions: ['.coffee']}, function(err) {
+  app.writeScripts(backend, publicDir, {extensions: ['.coffee']}, function(err) {
     cb(err, expressApp, handlers.upgrade);
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "mongodb": "^2.0.45",
-    "racer-bundle": "^0.2.0",
-    "racer-highway": "^3.0.2",
+    "racer-bundle": "^0.2.4",
+    "racer-highway": "^7.0.0",
     "serve-favicon": "^2.3.0",
     "sharedb": "^0.8.0",
     "sharedb-mongo": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coffeeify": "^1.1.0",
     "compression": "^1.6.0",
     "connect-mongo": "^0.8.2",
-    "derby": "^0.6.0",
+    "derby": "^0.8.0",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "mongodb": "^2.0.45",


### PR DESCRIPTION
Currently `npm install derby-starter` will fail (under npm 2.x.x) since the old derby target of 0.6.0 doesn't match any of the available published derby modules since all of 0.6.0 versions were tagged with "-alpha" which means they don't get picked up by the 0.6.0 semver resolution

Once that was fixed I realized we had updated derby but forgot to update the calls to `createStore()`

Also added some session options to avoid deprecation warnings from the recent upgrade to the latest express-session

cc: @nateps 